### PR TITLE
Remove time zone before datediff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# dbt_pendo_source v0.2.1
+
+## Under the Hood
+- The `valid_through` field within both the `stg_pendo__feature_history` and `stg_pendo__page_history` models have been updated to leverage the `dbt_utils.timestamp()` macro to be cast as timestamps. ([#10](https://github.com/fivetran/dbt_pendo_source/pull/10))
+
+## Contributors
+- [everettt](https://github.com/everettttt?tab=overview&from=2022-02-01&to=2022-02-11) ([#10](https://github.com/fivetran/dbt_pendo_source/pull/10))
+
 # dbt_pendo_source v0.2.0
 🎉 dbt v1.0.0 Compatibility 🎉
 ## 🚨 Breaking Changes 🚨

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - The `valid_through` field within both the `stg_pendo__feature_history` and `stg_pendo__page_history` models have been updated to leverage the `dbt_utils.timestamp()` macro to be cast as timestamps. ([#10](https://github.com/fivetran/dbt_pendo_source/pull/10))
 
 ## Contributors
-- [everettt](https://github.com/everettttt?tab=overview&from=2022-02-01&to=2022-02-11) ([#10](https://github.com/fivetran/dbt_pendo_source/pull/10))
+- [everettt](https://github.com/everettttt?tab=overview) ([#10](https://github.com/fivetran/dbt_pendo_source/pull/10))
 
 # dbt_pendo_source v0.2.0
 🎉 dbt v1.0.0 Compatibility 🎉

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'pendo_source'
-version: '0.2.0'
+version: '0.2.1'
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'pendo_source_integration_tests'
-version: '0.1.1'
+version: '0.2.1'
 
 require-dbt-version: ">=0.20.0"
 profile: 'integration_tests'

--- a/models/stg_pendo__feature_history.sql
+++ b/models/stg_pendo__feature_history.sql
@@ -35,7 +35,7 @@ final as (
         page_id,
         root_version_id,
         stable_version_id,
-        valid_through,
+        cast(valid_through as {{ dbt_utils.type_timestamp() }}) as valid_through,
         _fivetran_synced
 
     from fields

--- a/models/stg_pendo__page_history.sql
+++ b/models/stg_pendo__page_history.sql
@@ -33,7 +33,7 @@ final as (
         last_updated_by_user_id,
         root_version_id,
         stable_version_id,
-        valid_through,
+        cast(valid_through as {{ dbt_utils.type_timestamp() }}) as valid_through,
         _fivetran_synced
 
     from fields


### PR DESCRIPTION
**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package -->

The Fivetran Pendo connector stores `valid_through`/`validThrough` as type `TIMESTAMP WITH TIMEZONE` in Redshift. Convert it to `TIMESTAMP WITH NO TIMEZONE` before calculating a date difference.

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [ ] Yes (please provide breaking change details below.)
- [ ] No  (please provide explanation how the change is non breaking below.)

Not sure.

**Is this PR in response to a previously created Issue**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [x] Yes, #9
- [ ] No

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Other (please provide additional testing details below)

I ran it against my DWH.

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
- [ ] BigQuery
- [x] Redshift
- [ ] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)