### PR TITLE
doc(pendo source): Fix relative links in Pendo Source README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ packages:
 ```
 
 ## Package Maintenance
-The Fivetran team maintaining this package **only** maintains the latest version. We highly recommend you keep your `packages.yml` updated with the [dbt hub latest version](https://hub.getdbt.com/fivetran/pendo_source/latest/). You may refer to the [CHANGELOG](/CHANGELOG.md) and release notes for more information on changes across versions.
+The Fivetran team maintaining this package **only** maintains the latest version. We highly recommend you keep your `packages.yml` updated with the [dbt hub latest version](https://hub.getdbt.com/fivetran/pendo_source/latest/). You may refer to the [CHANGELOG](https://github.com/fivetran/dbt_pendo_source/blob/main/CHANGELOG.md) and release notes for more information on changes across versions.
 
 ## Configuration
 


### PR DESCRIPTION
Closes https://fivetran.atlassian.net/browse/RD-228380

Replaces relative links with absolute links that do not break when rendered in our docs.

